### PR TITLE
Improve compability

### DIFF
--- a/lab1/ll_test.py
+++ b/lab1/ll_test.py
@@ -5,13 +5,19 @@ import ctypes
 import os
 import unittest
 
-class LinkedList:
+
+class LinkedList(ctypes.Structure):
     cwd = os.getcwd()
     lib_path = os.path.join(cwd, 'libll.so')
     lib = ctypes.CDLL(lib_path)
 
     def __init__(self, head=0):
+        super(LinkedList, self).__init__()
+
         self.lib.linked_list_tostring.restype = ctypes.c_char_p
+        self.lib.linked_list_init.restype = ctypes.POINTER(LinkedList)
+        self.lib.linked_list_search_all.restype = ctypes.POINTER(LinkedList)
+
         if head == 0:
             self.head = self.lib.linked_list_init()
         else:
@@ -142,13 +148,12 @@ class LinkedListTest(unittest.TestCase):
         for i in range(10):
             ll.append(i)
         for i in range(10):
-            ll.append(9-i)
+            ll.append(9 - i)
         ret = ll.search_all(7)
         self.assertEqual(str(ret), '7->12')
         ret = ll.search_all(101)
         self.assertEqual(ret.size(), 0)
 
 
-
-unittest.main()
-
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
# Summary

1. According to [Python doc](https://docs.python.org/3/library/ctypes.html#structures-and-unions), make `LinkedList` inherited from `ctypes.Structure`.
2. Explicitly specify the return type of `linked_list_init` and `linked_list_search_all` inspired by @汪至圆.
3. Run unit test only when the script is run by passing it as a command to the Python interpreter.

11610127 is asking for extra credit (●'◡'●)